### PR TITLE
Dotnet format doing it's job

### DIFF
--- a/src/PlaywrightSharp.Abstractions/Accessibility/AccessibilitySnapshotOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/Accessibility/AccessibilitySnapshotOptions.cs
@@ -1,4 +1,4 @@
-﻿using PlaywrightSharp;
+using PlaywrightSharp;
 
 namespace PlaywrightSharp.Accessibility
 {

--- a/src/PlaywrightSharp.Abstractions/Accessibility/CheckedState.cs
+++ b/src/PlaywrightSharp.Abstractions/Accessibility/CheckedState.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp.Accessibility
+namespace PlaywrightSharp.Accessibility
 {
     /// <summary>
     /// Three-state boolean. See <seealso cref="SerializedAXNode.Checked"/> and <seealso cref="SerializedAXNode.Pressed"/>.

--- a/src/PlaywrightSharp.Abstractions/Accessibility/IAccessibility.cs
+++ b/src/PlaywrightSharp.Abstractions/Accessibility/IAccessibility.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace PlaywrightSharp.Accessibility
 {

--- a/src/PlaywrightSharp.Abstractions/Accessibility/SerializedAXNode.cs
+++ b/src/PlaywrightSharp.Abstractions/Accessibility/SerializedAXNode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 namespace PlaywrightSharp.Accessibility

--- a/src/PlaywrightSharp.Abstractions/AddTagOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/AddTagOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// <see cref="IPage.AddScriptTagAsync(AddTagOptions)"/> options.

--- a/src/PlaywrightSharp.Abstractions/BoundingBox.cs
+++ b/src/PlaywrightSharp.Abstractions/BoundingBox.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/BrowserArgOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/BrowserArgOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Options for <see cref="IBrowserType.GetDefaultArgs(BrowserArgOptions)"/>.

--- a/src/PlaywrightSharp.Abstractions/BrowserFetcherOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/BrowserFetcherOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Browser fetcher options used to construct a <see cref="IBrowserFetcher"/>.

--- a/src/PlaywrightSharp.Abstractions/ClickModifier.cs
+++ b/src/PlaywrightSharp.Abstractions/ClickModifier.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Modifiers for <see cref="ClickOptions.Modifiers"/>.

--- a/src/PlaywrightSharp.Abstractions/ClickOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/ClickOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/ColorScheme.cs
+++ b/src/PlaywrightSharp.Abstractions/ColorScheme.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Options for <see cref="IPage.EmulateMediaAsync(EmulateMedia)"/>.

--- a/src/PlaywrightSharp.Abstractions/ConnectOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/ConnectOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Options for <see cref="IBrowserType.ConnectAsync(ConnectOptions)"/>.

--- a/src/PlaywrightSharp.Abstractions/ConsoleEventArgs.cs
+++ b/src/PlaywrightSharp.Abstractions/ConsoleEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/ConsoleMessage.cs
+++ b/src/PlaywrightSharp.Abstractions/ConsoleMessage.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/ConsoleMessageLocation.cs
+++ b/src/PlaywrightSharp.Abstractions/ConsoleMessageLocation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace PlaywrightSharp

--- a/src/PlaywrightSharp.Abstractions/ConsoleType.cs
+++ b/src/PlaywrightSharp.Abstractions/ConsoleType.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Console type used on <see cref="ConsoleMessage"/>.

--- a/src/PlaywrightSharp.Abstractions/ContextPermission.cs
+++ b/src/PlaywrightSharp.Abstractions/ContextPermission.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Options for <see cref="IBrowserContext.SetPermissionsAsync(string, ContextPermission[])"/>.

--- a/src/PlaywrightSharp.Abstractions/DeviceDescriptor.cs
+++ b/src/PlaywrightSharp.Abstractions/DeviceDescriptor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/DeviceDescriptorName.cs
+++ b/src/PlaywrightSharp.Abstractions/DeviceDescriptorName.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Device descriptor name.

--- a/src/PlaywrightSharp.Abstractions/DialogEventArgs.cs
+++ b/src/PlaywrightSharp.Abstractions/DialogEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/DialogType.cs
+++ b/src/PlaywrightSharp.Abstractions/DialogType.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/DownOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/DownOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Options for <see cref="IKeyboard.DownAsync(string, DownOptions)"/>.

--- a/src/PlaywrightSharp.Abstractions/EmulateMedia.cs
+++ b/src/PlaywrightSharp.Abstractions/EmulateMedia.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Options for <see cref="IPage.EmulateMediaAsync(EmulateMedia)"/>.

--- a/src/PlaywrightSharp.Abstractions/FrameEventArgs.cs
+++ b/src/PlaywrightSharp.Abstractions/FrameEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/GeolocationOption.cs
+++ b/src/PlaywrightSharp.Abstractions/GeolocationOption.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/GotoOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/GotoOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Options for <see cref="IPage.GoToAsync(string, GoToOptions)"/> and <see cref="IFrame.GoToAsync(string, GoToOptions)"/>.

--- a/src/PlaywrightSharp.Abstractions/IBrowser.cs
+++ b/src/PlaywrightSharp.Abstractions/IBrowser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/PlaywrightSharp.Abstractions/IBrowserApp.cs
+++ b/src/PlaywrightSharp.Abstractions/IBrowserApp.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace PlaywrightSharp

--- a/src/PlaywrightSharp.Abstractions/IBrowserContext.cs
+++ b/src/PlaywrightSharp.Abstractions/IBrowserContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Threading.Tasks;
 

--- a/src/PlaywrightSharp.Abstractions/IBrowserFetcher.cs
+++ b/src/PlaywrightSharp.Abstractions/IBrowserFetcher.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 

--- a/src/PlaywrightSharp.Abstractions/IConnectionTransport.cs
+++ b/src/PlaywrightSharp.Abstractions/IConnectionTransport.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace PlaywrightSharp

--- a/src/PlaywrightSharp.Abstractions/IDialog.cs
+++ b/src/PlaywrightSharp.Abstractions/IDialog.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/IElementHandle.cs
+++ b/src/PlaywrightSharp.Abstractions/IElementHandle.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 

--- a/src/PlaywrightSharp.Abstractions/IFrame.cs
+++ b/src/PlaywrightSharp.Abstractions/IFrame.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace PlaywrightSharp

--- a/src/PlaywrightSharp.Abstractions/IKeyboard.cs
+++ b/src/PlaywrightSharp.Abstractions/IKeyboard.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/IMouse.cs
+++ b/src/PlaywrightSharp.Abstractions/IMouse.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/ITarget.cs
+++ b/src/PlaywrightSharp.Abstractions/ITarget.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Target class.

--- a/src/PlaywrightSharp.Abstractions/LaunchOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/LaunchOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Options for <see cref="IBrowserType.LaunchAsync(LaunchOptions)"/> and <see cref="IBrowserType.LaunchBrowserAppAsync(LaunchOptions)"/>.

--- a/src/PlaywrightSharp.Abstractions/MediaType.cs
+++ b/src/PlaywrightSharp.Abstractions/MediaType.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Options for <see cref="IPage.EmulateMediaAsync(EmulateMedia)"/>.

--- a/src/PlaywrightSharp.Abstractions/MessageReceivedEventArgs.cs
+++ b/src/PlaywrightSharp.Abstractions/MessageReceivedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/MouseButton.cs
+++ b/src/PlaywrightSharp.Abstractions/MouseButton.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// The type of button click to use with <see cref="IPage.ClickAsync(string, ClickOptions)"/>.

--- a/src/PlaywrightSharp.Abstractions/MoveOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/MoveOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Options for <see cref="IMouse.MoveAsync(decimal, decimal, MoveOptions)"/>.

--- a/src/PlaywrightSharp.Abstractions/NavigationOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/NavigationOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Navigation options used by <see cref="IPage.WaitForNavigationAsync(WaitForNavigationOptions)"/> and <see cref="IPage.SetContentAsync(string, NavigationOptions)"/>.

--- a/src/PlaywrightSharp.Abstractions/NetworkCookie.cs
+++ b/src/PlaywrightSharp.Abstractions/NetworkCookie.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Cookie data.

--- a/src/PlaywrightSharp.Abstractions/PageCloseOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/PageCloseOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Options for <see cref="IPage.CloseAsync(PageCloseOptions)"/>.

--- a/src/PlaywrightSharp.Abstractions/PageEvent.cs
+++ b/src/PlaywrightSharp.Abstractions/PageEvent.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Enums for <see cref="IPage.WaitForEvent{T}(PageEvent, WaitForEventOptions)"/>.

--- a/src/PlaywrightSharp.Abstractions/Platform.cs
+++ b/src/PlaywrightSharp.Abstractions/Platform.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Platform used by a <see cref="IBrowserFetcher"/>.

--- a/src/PlaywrightSharp.Abstractions/PopupEventArgs.cs
+++ b/src/PlaywrightSharp.Abstractions/PopupEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/RequestEventArgs.cs
+++ b/src/PlaywrightSharp.Abstractions/RequestEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/ResourceType.cs
+++ b/src/PlaywrightSharp.Abstractions/ResourceType.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/ResponseData.cs
+++ b/src/PlaywrightSharp.Abstractions/ResponseData.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Net;
 using System.Text;
 

--- a/src/PlaywrightSharp.Abstractions/RevisionInfo.cs
+++ b/src/PlaywrightSharp.Abstractions/RevisionInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/SameSite.cs
+++ b/src/PlaywrightSharp.Abstractions/SameSite.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// SameSite values in cookies.

--- a/src/PlaywrightSharp.Abstractions/ScreenshotOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/ScreenshotOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// <see cref="IPage.ScreenshotAsync(ScreenshotOptions)"/> options.

--- a/src/PlaywrightSharp.Abstractions/SetNetworkCookieParam.cs
+++ b/src/PlaywrightSharp.Abstractions/SetNetworkCookieParam.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Cookie set data.

--- a/src/PlaywrightSharp.Abstractions/TargetChangedArgs.cs
+++ b/src/PlaywrightSharp.Abstractions/TargetChangedArgs.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     ///  Event arguments used by target related events.

--- a/src/PlaywrightSharp.Abstractions/TransportClosedEventArgs.cs
+++ b/src/PlaywrightSharp.Abstractions/TransportClosedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/TransportFactory.cs
+++ b/src/PlaywrightSharp.Abstractions/TransportFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/PlaywrightSharp.Abstractions/Viewport.cs
+++ b/src/PlaywrightSharp.Abstractions/Viewport.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// View port data.

--- a/src/PlaywrightSharp.Abstractions/WaitForClickOption.cs
+++ b/src/PlaywrightSharp.Abstractions/WaitForClickOption.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Options for <see cref="ClickOptions.WaitFor"/>.

--- a/src/PlaywrightSharp.Abstractions/WaitForEventOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/WaitForEventOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Options for <see cref="IPage.WaitForEvent(PageEvent, WaitForEventOptions)"/>.

--- a/src/PlaywrightSharp.Abstractions/WaitForNavigationOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/WaitForNavigationOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp.Abstractions/WaitForOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/WaitForOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Optional waiting parameters.

--- a/src/PlaywrightSharp.Abstractions/WaitForSelectorOptions.cs
+++ b/src/PlaywrightSharp.Abstractions/WaitForSelectorOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Optional waiting parameters.

--- a/src/PlaywrightSharp.Abstractions/WaitUntilNavigation.cs
+++ b/src/PlaywrightSharp.Abstractions/WaitUntilNavigation.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Wait until navigation.

--- a/src/PlaywrightSharp.TestServer/SimpleCompressionMiddleware.cs
+++ b/src/PlaywrightSharp.TestServer/SimpleCompressionMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.IO.Compression;
 using System.Threading.Tasks;

--- a/src/PlaywrightSharp.TestServer/SimpleServer.cs
+++ b/src/PlaywrightSharp.TestServer/SimpleServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;

--- a/src/PlaywrightSharp.Tests/Accessibility/AccessibilityTests.cs
+++ b/src/PlaywrightSharp.Tests/Accessibility/AccessibilityTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using PlaywrightSharp.Accessibility;
 using PlaywrightSharp.Tests.Attributes;
 using PlaywrightSharp.Tests.BaseTests;

--- a/src/PlaywrightSharp.Tests/Accessibility/PlainTextContentEditableTests.cs
+++ b/src/PlaywrightSharp.Tests/Accessibility/PlainTextContentEditableTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using PlaywrightSharp.Accessibility;
 using PlaywrightSharp.Tests.Attributes;
 using PlaywrightSharp.Tests.BaseTests;

--- a/src/PlaywrightSharp.Tests/Accessibility/RootOptionTests.cs
+++ b/src/PlaywrightSharp.Tests/Accessibility/RootOptionTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using PlaywrightSharp.Accessibility;
 using PlaywrightSharp.Tests.Attributes;
 using PlaywrightSharp.Tests.BaseTests;

--- a/src/PlaywrightSharp.Tests/Attributes/SkipBrowserAndPlatformFact.cs
+++ b/src/PlaywrightSharp.Tests/Attributes/SkipBrowserAndPlatformFact.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using Xunit;
 

--- a/src/PlaywrightSharp.Tests/BaseTests/PlaywrightSharpBaseTest.cs
+++ b/src/PlaywrightSharp.Tests/BaseTests/PlaywrightSharpBaseTest.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using PlaywrightSharp.TestServer;
 using Xunit.Abstractions;
 

--- a/src/PlaywrightSharp.Tests/BaseTests/PlaywrightSharpBrowserBaseTest.cs
+++ b/src/PlaywrightSharp.Tests/BaseTests/PlaywrightSharpBrowserBaseTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Xunit.Abstractions;

--- a/src/PlaywrightSharp.Tests/BaseTests/PlaywrightSharpBrowserContextBaseTest.cs
+++ b/src/PlaywrightSharp.Tests/BaseTests/PlaywrightSharpBrowserContextBaseTest.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/PlaywrightSharp.Tests/BaseTests/PlaywrightSharpLoaderCollection.cs
+++ b/src/PlaywrightSharp.Tests/BaseTests/PlaywrightSharpLoaderCollection.cs
@@ -1,4 +1,4 @@
-﻿using Xunit;
+using Xunit;
 
 namespace PlaywrightSharp.Tests.BaseTests
 {

--- a/src/PlaywrightSharp.Tests/BaseTests/PlaywrightSharpLoaderFixture.cs
+++ b/src/PlaywrightSharp.Tests/BaseTests/PlaywrightSharpLoaderFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using PlaywrightSharp.TestServer;
 

--- a/src/PlaywrightSharp.Tests/BaseTests/PlaywrightSharpPageBaseTest.cs
+++ b/src/PlaywrightSharp.Tests/BaseTests/PlaywrightSharpPageBaseTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Xunit.Abstractions;
 
 namespace PlaywrightSharp.Tests.BaseTests

--- a/src/PlaywrightSharp.Tests/Browser/CloseTests.cs
+++ b/src/PlaywrightSharp.Tests/Browser/CloseTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/PlaywrightSharp.Tests/Browser/DisconnectTests.cs
+++ b/src/PlaywrightSharp.Tests/Browser/DisconnectTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/PlaywrightSharp.Tests/Browser/IsConnectedTests.cs
+++ b/src/PlaywrightSharp.Tests/Browser/IsConnectedTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/PlaywrightSharp.Tests/BrowserContext/BrowserContextTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContext/BrowserContextTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;

--- a/src/PlaywrightSharp.Tests/BrowserContext/BypassCSPTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContext/BypassCSPTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;

--- a/src/PlaywrightSharp.Tests/BrowserContext/ClearCookiesTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContext/ClearCookiesTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.Attributes;
 using PlaywrightSharp.Tests.BaseTests;

--- a/src/PlaywrightSharp.Tests/BrowserContext/CookiesTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContext/CookiesTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.Attributes;
 using PlaywrightSharp.Tests.BaseTests;

--- a/src/PlaywrightSharp.Tests/BrowserContext/DefaultBrowserContextTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContext/DefaultBrowserContextTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;

--- a/src/PlaywrightSharp.Tests/BrowserContext/GeolocationTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContext/GeolocationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Threading.Tasks;

--- a/src/PlaywrightSharp.Tests/BrowserContext/IgnoreHttpsErrorsTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContext/IgnoreHttpsErrorsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections.Features;

--- a/src/PlaywrightSharp.Tests/BrowserContext/JavaScriptEnabledTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContext/JavaScriptEnabledTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;

--- a/src/PlaywrightSharp.Tests/BrowserContext/SetCookiesTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContext/SetCookiesTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.Attributes;
 using PlaywrightSharp.Tests.BaseTests;

--- a/src/PlaywrightSharp.Tests/BrowserContext/SetUserAgentTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContext/SetUserAgentTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;

--- a/src/PlaywrightSharp.Tests/BrowserContext/TimezoneTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContext/TimezoneTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Threading.Tasks;

--- a/src/PlaywrightSharp.Tests/Chromium/Browser/TargetEventsTests.cs
+++ b/src/PlaywrightSharp.Tests/Chromium/Browser/TargetEventsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;

--- a/src/PlaywrightSharp.Tests/Chromium/BrowserFetcherTests.cs
+++ b/src/PlaywrightSharp.Tests/Chromium/BrowserFetcherTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/src/PlaywrightSharp.Tests/Chromium/Launcher/BrowserUrlOptionTests.cs
+++ b/src/PlaywrightSharp.Tests/Chromium/Launcher/BrowserUrlOptionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.Attributes;

--- a/src/PlaywrightSharp.Tests/Chromium/Launcher/WebSocketOptionsTests.cs
+++ b/src/PlaywrightSharp.Tests/Chromium/Launcher/WebSocketOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.Attributes;

--- a/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleBoundingBoxTestsTests.cs
+++ b/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleBoundingBoxTestsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;

--- a/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleClickTests.cs
+++ b/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleClickTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleContentFrameTests.cs
+++ b/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleContentFrameTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleFillTests.cs
+++ b/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleFillTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleHoverTests.cs
+++ b/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleHoverTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleOwnerFrameTests.cs
+++ b/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleOwnerFrameTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleScrollIntoViewIfNeededTests.cs
+++ b/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleScrollIntoViewIfNeededTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.Attributes;
 using PlaywrightSharp.Tests.BaseTests;

--- a/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleVisibleRatioTests.cs
+++ b/src/PlaywrightSharp.Tests/ElementHandle/ElementHandleVisibleRatioTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;

--- a/src/PlaywrightSharp.Tests/Frame/FrameEvaluateHandleTests.cs
+++ b/src/PlaywrightSharp.Tests/Frame/FrameEvaluateHandleTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/PlaywrightSharp.Tests/Frame/FrameEvaluateTests.cs
+++ b/src/PlaywrightSharp.Tests/Frame/FrameEvaluateTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;

--- a/src/PlaywrightSharp.Tests/Frame/FrameManagementTests.cs
+++ b/src/PlaywrightSharp.Tests/Frame/FrameManagementTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;

--- a/src/PlaywrightSharp.Tests/Frame/GoToTests.cs
+++ b/src/PlaywrightSharp.Tests/Frame/GoToTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/src/PlaywrightSharp.Tests/Frame/JsHandle/JSHandleAsElementTests.cs
+++ b/src/PlaywrightSharp.Tests/Frame/JsHandle/JSHandleAsElementTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/PlaywrightSharp.Tests/Frame/JsHandle/JSHandleGetPropertiesTests.cs
+++ b/src/PlaywrightSharp.Tests/Frame/JsHandle/JSHandleGetPropertiesTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/PlaywrightSharp.Tests/Frame/JsHandle/JSHandleJsonValueTests.cs
+++ b/src/PlaywrightSharp.Tests/Frame/JsHandle/JSHandleJsonValueTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/PlaywrightSharp.Tests/Frame/WaitForNavigationTests.cs
+++ b/src/PlaywrightSharp.Tests/Frame/WaitForNavigationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/src/PlaywrightSharp.Tests/FrameUtils.cs
+++ b/src/PlaywrightSharp.Tests/FrameUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;

--- a/src/PlaywrightSharp.Tests/Mouse/MouseTests.cs
+++ b/src/PlaywrightSharp.Tests/Mouse/MouseTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;

--- a/src/PlaywrightSharp.Tests/Page/EmulateMediaColorSchemeTests.cs
+++ b/src/PlaywrightSharp.Tests/Page/EmulateMediaColorSchemeTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Threading.Tasks;

--- a/src/PlaywrightSharp.Tests/Page/EmulateMediaTypeTests.cs
+++ b/src/PlaywrightSharp.Tests/Page/EmulateMediaTypeTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Threading.Tasks;

--- a/src/PlaywrightSharp.Tests/Page/EmulateTests.cs
+++ b/src/PlaywrightSharp.Tests/Page/EmulateTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Threading.Tasks;

--- a/src/PlaywrightSharp.Tests/Page/Events/DialogTests.cs
+++ b/src/PlaywrightSharp.Tests/Page/Events/DialogTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;

--- a/src/PlaywrightSharp.Tests/Page/GoBackTests.cs
+++ b/src/PlaywrightSharp.Tests/Page/GoBackTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Net;

--- a/src/PlaywrightSharp.Tests/Page/GoToTests.cs
+++ b/src/PlaywrightSharp.Tests/Page/GoToTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Net;

--- a/src/PlaywrightSharp.Tests/Page/NetworkIdleTests.cs
+++ b/src/PlaywrightSharp.Tests/Page/NetworkIdleTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;

--- a/src/PlaywrightSharp.Tests/Page/ReloadTests.cs
+++ b/src/PlaywrightSharp.Tests/Page/ReloadTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Net;

--- a/src/PlaywrightSharp.Tests/Page/ViewportTests.cs
+++ b/src/PlaywrightSharp.Tests/Page/ViewportTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Threading.Tasks;

--- a/src/PlaywrightSharp.Tests/Page/WaitForNavigationTests.cs
+++ b/src/PlaywrightSharp.Tests/Page/WaitForNavigationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Net;

--- a/src/PlaywrightSharp.Tests/PageExtensions.cs
+++ b/src/PlaywrightSharp.Tests/PageExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 namespace PlaywrightSharp.Tests

--- a/src/PlaywrightSharp.Tests/PlaywrightSharp/ConnectTests.cs
+++ b/src/PlaywrightSharp.Tests/PlaywrightSharp/ConnectTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/PlaywrightSharp.Tests/PlaywrightSharp/DefaultArgumentsTests.cs
+++ b/src/PlaywrightSharp.Tests/PlaywrightSharp/DefaultArgumentsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/PlaywrightSharp.Tests/PlaywrightSharp/ExecutablePathTests.cs
+++ b/src/PlaywrightSharp.Tests/PlaywrightSharp/ExecutablePathTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/PlaywrightSharp.Tests/PlaywrightSharp/LaunchTests.cs
+++ b/src/PlaywrightSharp.Tests/PlaywrightSharp/LaunchTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/PlaywrightSharp.Tests/PlaywrightSharp/LaunchWebSocketOptionTests.cs
+++ b/src/PlaywrightSharp.Tests/PlaywrightSharp/LaunchWebSocketOptionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/PlaywrightSharp.Tests/PlaywrightSharp/NameTests.cs
+++ b/src/PlaywrightSharp.Tests/PlaywrightSharp/NameTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/PlaywrightSharp.Tests/PlaywrightSharp/TopLevelRequiresTests.cs
+++ b/src/PlaywrightSharp.Tests/PlaywrightSharp/TopLevelRequiresTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/PlaywrightSharp.Tests/PlaywrightSharp/UserDataDirTests.cs
+++ b/src/PlaywrightSharp.Tests/PlaywrightSharp/UserDataDirTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/PlaywrightSharp.Tests/RequestInterception/InterceptionContinueTests.cs
+++ b/src/PlaywrightSharp.Tests/RequestInterception/InterceptionContinueTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using PlaywrightSharp.Tests.BaseTests;
 using Xunit;

--- a/src/PlaywrightSharp.Tests/TestConstants.cs
+++ b/src/PlaywrightSharp.Tests/TestConstants.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/src/PlaywrightSharp/BrowserFetcherConfig.cs
+++ b/src/PlaywrightSharp/BrowserFetcherConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace PlaywrightSharp
+namespace PlaywrightSharp
 {
     /// <summary>
     /// Configuration for <see cref="BrowserFetcher"/>.

--- a/src/PlaywrightSharp/Helpers/TaskHelper.cs
+++ b/src/PlaywrightSharp/Helpers/TaskHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/PlaywrightSharp/NavigationException.cs
+++ b/src/PlaywrightSharp/NavigationException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 
 namespace PlaywrightSharp

--- a/src/PlaywrightSharp/Playwright.cs
+++ b/src/PlaywrightSharp/Playwright.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp/PlaywrightSharpException.cs
+++ b/src/PlaywrightSharp/PlaywrightSharpException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 
 namespace PlaywrightSharp

--- a/src/PlaywrightSharp/SelectorException.cs
+++ b/src/PlaywrightSharp/SelectorException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PlaywrightSharp
 {

--- a/src/PlaywrightSharp/TargetClosedException.cs
+++ b/src/PlaywrightSharp/TargetClosedException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PlaywrightSharp
 {


### PR DESCRIPTION
It's removing the [byte order mark](https://en.wikipedia.org/wiki/Byte_order_mark).

![image](https://user-images.githubusercontent.com/2198466/74530681-6ec62200-4f09-11ea-9331-aaf44f82767d.png)
